### PR TITLE
zoomToBoundingBox zoom bug fix

### DIFF
--- a/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
+++ b/osmdroid-android/src/main/java/org/osmdroid/views/MapView.java
@@ -396,14 +396,14 @@ public class MapView extends ViewGroup implements IMapView, MapViewConstants,
 
 
 		// Zoom to boundingBox center, at calculated maximum allowed zoom level
+		int zoom = (int) (requiredLatitudeZoom < requiredLongitudeZoom ?
+					requiredLatitudeZoom : requiredLongitudeZoom);
+		if(zoom > getMaxZoomLevel())
+			zoom = getMaxZoomLevel()
 		if(animated) {
-			getController().zoomTo((int) (
-				requiredLatitudeZoom < requiredLongitudeZoom ?
-					requiredLatitudeZoom : requiredLongitudeZoom));
+			getController().zoomTo(zoom);
 		} else {
-			getController().setZoom((int) (
-				requiredLatitudeZoom < requiredLongitudeZoom ?
-					requiredLatitudeZoom : requiredLongitudeZoom));
+			getController().setZoom(zoom);
 		}
 
 		getController().setCenter(


### PR DESCRIPTION
There was a problem in some specific phone devices that the calculated zoom give a bigger number than the maximum zoom for the selected Map Tile Provider then zoom was never happening. 

In my case the calculated zoom was giving 19 as value but maximum zoom for my map was 18 so the result was that map was not zooming at all even if the map was already draw and all properly loaded.
